### PR TITLE
Publish a patch from our fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
           filters:
             branches:
               only:
-                - 'improved-business-days'
+                - homebound-patch-publish
 
 jobs:
   build:
@@ -29,6 +29,4 @@ jobs:
     steps:
       - checkout
       - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
-      - run: npm i -g yarn
-      - run: git checkout homebound-patch-publish
       - run: ./scripts/homebound-publish-patch.sh improved-business-days

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,9 @@ jobs:
             - '92:4f:71:a8:fd:a2:99:e1:87:13:0e:7e:b5:ec:4e:a2'
       - checkout
       - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> $HOME/.npmrc'
-      - run: ./scripts/homebound-publish-patch.sh improved-business-days
+      - run:
+          command: ./scripts/homebound-publish-patch.sh improved-business-days
+          environment:
+            GIT_AUTHOR_NAME: Circle CI
+            GIT_COMMITTER_NAME: Circle CI
+            EMAIL: eng@homebound.com

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@5.0.0
+
+node-image: &node-image
+  image: cimg/node:14.16.0
+  auth:
+    username: $DOCKERHUB_USERNAME
+    password: $DOCKERHUB_ACCESS_TOKEN
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - build:
+          context:
+            - dockerhub
+            - npm
+          filters:
+            branches:
+              only:
+                - 'improved-business-days'
+
+jobs:
+  build:
+    docker:
+      - <<: *node-image
+    steps:
+      - checkout
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - run: npm i -g yarn
+      - run: git checkout homebound-patch-publish
+      - run: ./scripts/homebound-publish-patch.sh improved-business-days

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
       - build:
           context:
             - dockerhub
-            - npm
+            - npm-publish
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,5 @@ jobs:
           fingerprints:
             - '92:4f:71:a8:fd:a2:99:e1:87:13:0e:7e:b5:ec:4e:a2'
       - checkout
-      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> $HOME/.npmrc'
       - run: ./scripts/homebound-publish-patch.sh improved-business-days

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
     docker:
       - <<: *node-image
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - '92:4f:71:a8:fd:a2:99:e1:87:13:0e:7e:b5:ec:4e:a2'
       - checkout
       - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
       - run: ./scripts/homebound-publish-patch.sh improved-business-days

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ does not automatically trigger a new patch publish (see [below](#publishing-the-
 
 ### Publishing the Patch Package
 
+
 There are two distinct cases you might want to trigger a new package publish:
 
 1. If you've made changes on the `improved-business-days` branch and want to release them.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ and other docs.
 
 ## Homebound Fork
 
-This is Homebound's fork of `date-fns`. We forked this repository to extend the functionality of the `businessDate`
+This is Homebound's fork of `date-fns`. We forked this repository to extend the functionality of the `businessDays`
 functions. Our plan is to PR these improvements back to the mainstream project. However, in the meantime, we have
 logic to publish a `.patch` file to layer this functionality on top of the upstream `date-fns` package via the
 [`patch-package` project](https://github.com/ds300/patch-package).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ In either case, you trigger a release by running the [workflow in CircleCI](http
 The release process pulls the latest release tag, merges the `improved-business-days` branch and builds the TypeScript
 code. Then, it runs the `patch-package` process to produce a `.patch` file representing the changes.
 
-We publish the private NPM package, `@homebound/date-fns-patch` package for convenience. The versioning convention is
+We publish the NPM package `@homebound/date-fns-patch` for convenience. The versioning convention is
 `<upstream-version>-rc.<i>`. For instance, `2.28.0-rc.1` is the first patch we built against the upstream 2.28.0 version.
 Because we might publish several revisions against the same upstream version, we simply increment the `-rc.<i>` tag each
 time we release. For example, the third publish of the branch against the upstream 2.28.0 version will create

--- a/README.md
+++ b/README.md
@@ -64,6 +64,63 @@ and other docs.
 <br />
 <!-- END OF README-JOB SECTION -->
 
+## Homebound Fork
+
+This is Homebound's fork of `date-fns`. We forked this repository to extend the functionality of the `businessDate`
+functions. Our plan is to PR these improvements back to the mainstream project. However, in the meantime, we have
+logic to publish a `.patch` file to layer this functionality on top of the upstream `date-fns` package via the
+[`patch-package` project](https://github.com/ds300/patch-package).
+
+### Our Branch
+
+Currently, our code changes live on the [`improved-business-days`](https://github.com/homebound-team/date-fns/tree/improved-business-days)
+branch on our fork. The intention with this branch is that it's well-tested and will be PR'ed against the upstream
+project.
+
+This branch is tested using the same GitHub actions that run on the upstream project. When you push to this branch, it
+does not automatically trigger a new patch publish (see [below](#publishing-the-patch-package) for how to do that).
+
+### Publishing the Patch Package
+
+There are two distinct cases you might want to trigger a new package publish:
+
+1. If you've made changes on the `improved-business-days` branch and want to release them.
+1. If a new version of `date-fns` is released upstream.
+
+In either case, you trigger a release by running the [workflow in CircleCI](https://app.circleci.com/pipelines/github/homebound-team/date-fns?branch=homebound-patch-publish&filter=all). Just pick the last workflow run and click the "Rerun workflow from the start" button.
+
+![](https://imgur.com/XFnUtNc)
+
+The release process pulls the latest release tag, merges the `improved-business-days` branch and builds the TypeScript
+code. Then, it runs the `patch-package` process to produce a `.patch` file representing the changes.
+
+We publish the private NPM package, `@homebound/date-fns-patch` package for convenience. The versioning convention is
+`<upstream-version>-rc.<i>`. For instance, `2.28.0-rc.1` is the first patch we built against the upstream 2.28.0 version.
+Because we might publish several revisions against the same upstream version, we simply increment the `-rc.<i>` tag each
+time we release. For example, the third publish of the branch against the upstream 2.28.0 version will create
+`@homebound/date-fns-patch@2.28.0-rc.3`.
+
+### Using `@homebound/date-fns-patch`
+
+1. You need to have `patch-package` set up in the consuming project. Setup instructions
+  [are found in `patch-package`](https://github.com/ds300/patch-package) README.
+1. Install the `@homebound/date-fns-patch` NPM package via `npm install --save-dev @homebound/date-fns-patch`.
+
+When you install the package, you'll see a `date-fns` patch appear in the `patches` directory:
+
+```console
+> ls -al patches
+total 4
+-rw-r--r-- 1 blimmer wheel 1213 Feb  2 17:54 date-fns+2.28.0.patch
+```
+
+Now `patch-package` will automatically apply this patch, and you can use the new methods directly in your project.
+
+### Troubleshooting
+
+If you run into any problems with this process, please reach out to [Ben Limmer](https://benlimmer.com/freelance) in
+Slack.
+
 ## License
 
 [MIT © Sasha Koss](https://kossnocorp.mit-license.org/)

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -99,7 +99,7 @@ git checkout "v$LATEST_UPSTREAM_VERSION"
 git checkout -b "homebound-patch-v$LATEST_UPSTREAM_VERSION"
 
 echo "Merging $BRANCH_TO_MERGE..."
-git merge --no-commit "$BRANCH_TO_MERGE"
+git merge --no-commit origin/"$BRANCH_TO_MERGE"
 
 echo "Building..."
 yarn install

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -58,7 +58,7 @@ build() {
 
   # Build types
   ./scripts/build/build.sh
-  git add -a
+  git add -A
   git commit -m "generate and commit types"
 
   # Then build the NPM package
@@ -127,6 +127,7 @@ git push origin "homebound-patch-v$NEW_PATCH_PACKAGE_VERSION"
 
 echo "Building..."
 build
+git push origin "homebound-patch-v$NEW_PATCH_PACKAGE_VERSION"
 
 echo "Creating patch..."
 create_patch "$LATEST_UPSTREAM_VERSION"

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -53,6 +53,19 @@ merge_upstream_master() {
   git push origin master --follow-tags
 }
 
+build() {
+  yarn install
+
+  # Build types
+  ./scripts/build/build.sh
+  git add -a
+  git commit -m "generate and commit types"
+
+  # Then build the NPM package
+  env VERSION=v"$LATEST_UPSTREAM_VERSION" ./scripts/release/writeVersion.js
+  env VERSION=v"$LATEST_UPSTREAM_VERSION" PACKAGE_OUTPUT_PATH="$BUILD_DIR" ./scripts/build/package.sh
+}
+
 create_patch() {
   mkdir -p "$PATCH_DIR"
   cd "$PATCH_DIR"
@@ -113,9 +126,7 @@ git merge --no-commit origin/"$BRANCH_TO_MERGE"
 git push origin "homebound-patch-v$NEW_PATCH_PACKAGE_VERSION"
 
 echo "Building..."
-yarn install
-env VERSION=v"$LATEST_UPSTREAM_VERSION" ./scripts/release/writeVersion.js
-env VERSION=v"$LATEST_UPSTREAM_VERSION" PACKAGE_OUTPUT_PATH="$BUILD_DIR" ./scripts/build/package.sh
+build
 
 echo "Creating patch..."
 create_patch "$LATEST_UPSTREAM_VERSION"

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+PATCH_PACKAGE_NAME="@homebound/date-fns-patch"
+
+WORKING_DIR="$SCRIPT_DIR"/../tmp
+BUILD_DIR="$WORKING_DIR/date-fns"
+PATCH_DIR="$WORKING_DIR/patch"
+
+BRANCH_TO_MERGE="$1"
+if [[ -z "$BRANCH_TO_MERGE" ]]; then
+  echo "You must pass the name of the branch with homebound-specific changes as a param! (e.g., ./scripts/homebound/publish-patch.sh BRANCH_NAME)"
+  exit 1
+fi
+
+LATEST_UPSTREAM_VERSION=$(npm view date-fns version)
+echo "The latest version of date-fns published to NPM is $LATEST_UPSTREAM_VERSION"
+
+get_patch_package_version() {
+  local all_versions
+  all_versions=$(npm view $PATCH_PACKAGE_NAME versions --json)
+
+  i=1
+  while true; do
+    local possible_version="$LATEST_UPSTREAM_VERSION-rc.$i"
+    local exists
+    exists=$(echo "$all_versions" | jq 'index('\""$possible_version"\"')')
+
+    if [[ "$exists" == "null" ]]; then
+      echo "$possible_version"
+      break
+    else
+      i=$((i + 1))
+    fi
+  done
+}
+NEW_PATCH_PACKAGE_VERSION=$(get_patch_package_version)
+echo "We'll publish $PATCH_PACKAGE_NAME@$NEW_PATCH_PACKAGE_VERSION."
+
+merge_upstream_master() {
+  git remote add upstream https://github.com/date-fns/date-fns.git
+  git fetch upstream --tags
+  git checkout master
+  git pull upstream master --rebase
+  git push origin master --follow-tags
+}
+
+create_patch() {
+  mkdir -p "$PATCH_DIR"
+  cd "$PATCH_DIR"
+
+  cat >"$PATCH_DIR"/package.json <<EOL
+{
+  "name": "${PATCH_PACKAGE_NAME}",
+  "version": "${NEW_PATCH_PACKAGE_VERSION}",
+  "repository": "https://github.com/homebound-team/date-fns",
+  "description": "Provides a patch file for date-fns. Intended for use with patch-package NPM package.",
+  "scripts": {
+    "postinstall": "bash ./scripts/copy-patch-to-installer.sh"
+  },
+  "peerDependencies": {
+    "patch-package": "^6"
+  },
+  "devDependencies": {
+    "patch-package": "^6",
+    "date-fns": "${LATEST_UPSTREAM_VERSION}"
+  }
+}
+EOL
+
+  mkdir "$PATCH_DIR"/scripts
+  cat >"$PATCH_DIR"/scripts/copy-patch-to-installer.sh <<EOL
+#! /bin/bash
+
+SCRIPT_DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
+PATCH_FILE="\$SCRIPT_DIR/../patches/date-fns+${LATEST_UPSTREAM_VERSION}.patch"
+
+mkdir -p ../../../patches && cp "\$PATCH_FILE" ../../../patches/
+EOL
+
+  npm i --ignore-scripts
+
+  rm -fr "$PATCH_DIR/node_modules/date-fns"
+  mv -f "$BUILD_DIR" "$PATCH_DIR/node_modules/"
+  npx patch-package date-fns
+
+  npm publish
+}
+
+echo "Merging upstream date-fns master branch to our fork..."
+merge_upstream_master
+
+echo "Checking out version $LATEST_UPSTREAM_VERSION by tag..."
+git checkout "v$LATEST_UPSTREAM_VERSION"
+git checkout -b "homebound-patch-v$LATEST_UPSTREAM_VERSION"
+
+echo "Merging $BRANCH_TO_MERGE..."
+git merge --no-commit "$BRANCH_TO_MERGE"
+
+echo "Building..."
+env VERSION=v"$LATEST_UPSTREAM_VERSION" ./scripts/release/writeVersion.js
+env VERSION=v"$LATEST_UPSTREAM_VERSION" PACKAGE_OUTPUT_PATH="$BUILD_DIR" ./scripts/build/package.sh
+
+echo "Creating patch..."
+create_patch "$LATEST_UPSTREAM_VERSION"

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -96,10 +96,11 @@ merge_upstream_master
 
 echo "Checking out version $LATEST_UPSTREAM_VERSION by tag..."
 git checkout "v$LATEST_UPSTREAM_VERSION"
-git checkout -b "homebound-patch-v$LATEST_UPSTREAM_VERSION"
+git checkout -b "homebound-patch-v$NEW_PATCH_PACKAGE_VERSION"
 
 echo "Merging $BRANCH_TO_MERGE..."
 git merge --no-commit origin/"$BRANCH_TO_MERGE"
+git push origin "homebound-patch-v$NEW_PATCH_PACKAGE_VERSION"
 
 echo "Building..."
 yarn install

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -98,8 +98,7 @@ EOL
   mv -f "$BUILD_DIR" "$PATCH_DIR/node_modules/"
   npx patch-package date-fns
 
-  # TODO: remove dry run flag
-  npm publish --dry-run
+  npm publish
 }
 
 echo "Merging upstream date-fns master branch to our fork..."

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -87,7 +87,8 @@ EOL
   mv -f "$BUILD_DIR" "$PATCH_DIR/node_modules/"
   npx patch-package date-fns
 
-  npm publish
+  # TODO: remove dry run flag
+  npm publish --dry-run
 }
 
 echo "Merging upstream date-fns master branch to our fork..."
@@ -101,6 +102,7 @@ echo "Merging $BRANCH_TO_MERGE..."
 git merge --no-commit "$BRANCH_TO_MERGE"
 
 echo "Building..."
+yarn install
 env VERSION=v"$LATEST_UPSTREAM_VERSION" ./scripts/release/writeVersion.js
 env VERSION=v"$LATEST_UPSTREAM_VERSION" PACKAGE_OUTPUT_PATH="$BUILD_DIR" ./scripts/build/package.sh
 

--- a/scripts/homebound-publish-patch.sh
+++ b/scripts/homebound-publish-patch.sh
@@ -63,6 +63,7 @@ create_patch() {
   "name": "${PATCH_PACKAGE_NAME}",
   "version": "${NEW_PATCH_PACKAGE_VERSION}",
   "repository": "https://github.com/homebound-team/date-fns",
+  "homepage": "https://github.com/homebound-team/date-fns/blob/homebound-patch-publish/README.md#using-homebounddate-fns-patch",
   "description": "Provides a patch file for date-fns. Intended for use with patch-package NPM package.",
   "scripts": {
     "postinstall": "bash ./scripts/copy-patch-to-installer.sh"


### PR DESCRIPTION
This PR contains the logic to publish the `@homebound/date-fns-patch` package. This process allows us to introduce new date-fns behavior seamlessly to our projects while still using the upstream dependency. This process works by leveraging `patch-packages`.

The best place to start reviewing this change is in the README. I'm leaving this as a draft PR because I think we should keep the `master` branch in-sync with upstream.